### PR TITLE
Create README and Issue and PR templates

### DIFF
--- a/ISSUE_TEMPLATE/1-bug-report.md
+++ b/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,37 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!-- Thank you for reporting a possible bug.  Please fill in as much of the template below as you can. -->
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**Steps to Reproduce**
+<!-- Steps to reproduce the behavior. -->
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Environment information**
+ - Device: <!-- [e.g. MacBook] -->
+ - OS: <!-- [e.g. MacOS 10.14.3] -->
+ - Browser and version: <!-- [e.g. Firefox 65.0.1, Chrome 73.0.3683.75, Safari 12.0.3] -->
+ - Plugins and version: <!-- [e.g. 1.1.0] -->
+ - Theme and version: <!-- [e.g. Twenty Nineteen 1.3] -->
+ - Other installed plugin(s) and version(s):
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/ISSUE_TEMPLATE/2-enhancement.md
+++ b/ISSUE_TEMPLATE/2-enhancement.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F680 Enhancement"
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+<!-- Thank you for suggesting an idea to make things better.  Please fill in as much of the template below as you can. -->
+
+**Is your enhancement related to a problem? Please describe.**
+<!-- Please describe the problem you are trying to solve. -->
+
+**Describe the solution you'd like**
+<!-- Please describe the desired behavior. -->
+
+**Designs**
+<!-- If applicable, add mockups/screenshots/etc. to help explain your solution. -->
+
+**Describe alternatives you've considered**
+<!-- Please describe alternative solutions or features you have considered. -->
+
+**Additional context**
+<!-- Add any other context about the enhancement here. -->

--- a/ISSUE_TEMPLATE/3-help.md
+++ b/ISSUE_TEMPLATE/3-help.md
@@ -1,0 +1,13 @@
+---
+name: "❓ Need help?"
+about: Ask us a question, we're here to help!
+title: ''
+labels: question
+assignees: ''
+
+---
+
+<!-- If you have a question that is neither a bug report nor an enhancement, then please post it here!  Please fill in as much of the template below as you can. -->
+
+**Describe your question**
+<!-- A clear and concise description of what your question is. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+### Requirements
+
+Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
+-->
+
+### Description of the Change
+
+<!--
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected. -->
+
+### Benefits
+
+<!-- What benefits will be realized by the code change? -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+What process did you follow to verify that your change has the desired effects?
+
+- How did you verify that all new functionality works as expected?
+- How did you verify that all changed functionality works as expected?
+- How did you verify that the change has not introduced any regressions?
+
+Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
+-->
+
+### Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my change.
+- [ ] All new and existing tests passed.
+
+<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
+
+### Applicable Issues
+
+<!-- Enter any applicable Issues here -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# .github
-10up's community files
+# 10up Default Community Health Files
+
+GitHub supports [organization-wide community health files](https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/) in a specially named `.github` repository to serve as organization-wide defaults for all repositories within their organization.  Where sensible, custom community health files should be created for our repos, but that's not always necessary or practical.
+
+The following are the default `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `ISSUE_TEMPLATES`, and `PULL_REQUEST_TEMPLATE.md` files for 10up repositories that do not have custom ones themselves.  Note that these default files won’t appear in the file browser or Git history for each repository, but they will be surfaced throughout developers’ workflows, such as when opening a new issue or when viewing the Community Profile, just as if it were committed to the repository directly.


### PR DESCRIPTION
This adds some basic details to README.md  about the default community health files that will be added to 10up repos that are otherwise missing these files.  I'm not certain if the relative link will work and whether the leading slash is correct or not, so we'll just have to merge and see.