### PR TITLE
Fix changelog heading in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,6 +51,6 @@ Describe the actions you performed (e.g., commands you ran, text you typed, butt
 
 <!-- Enter any applicable Issues here -->
 
-## Changelog Entry
+### Changelog Entry
 
 <!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The Changelog Entry section was an H2 instead of an H3 like the rest of the sections, this PR updates the Changelog Entry section to an H3.

### Alternate Designs

keep as-is

### Benefits

all input areas in the PR template are the same heading level

### Possible Drawbacks

none identified

### Verification Process

Manually checked via GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

## Changelog Entry

n/a
