### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of this project are currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| #.#.#   | :white_check_mark: |
+| #.#.#   | :white_check_mark: |
+| <#.#.#  | :x:                |
+
+## Reporting a Vulnerability
+
+To report a security issue please email details to opensource@10up.com with a descriptive subject line.  This account is monitored by a small team within 10up.  In addition, please include the following information along with your report:
+
+- Your name and affiliation (if any).
+- A description of the technical details of the vulnerability.  It is very important to let us know how we can reproduce your findings.
+- An explanation who can exploit this vulnerability, and what they gain when doing so -- write an attack scenario.  This will help us evaluate your report quickly, especially if the issue is complex.
+- Whether this vulnerability is public or known to third parties.  If it is, please provide details.
+
+If you believe that an existing (public) issue is security-related, please send an email to opensource@10up.com.  The email should include the issue ID and a short description of why it should be handled according to this security policy.
+
+## Responding to Vulnerability Reports
+
+10up takes security bugs seriously.  We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+Your email will be acknowledged within ONE business day, and you will receive a more detailed response to your email within SEVEN days indicating the next steps in handling your report.  After the initial reply to your report, 10up will keep you informed of the progress being made towards a fix and announcement.  If your vulnerability report is accepted, then we will work with you on a fix and follow the process noted below on [disclosing vulnerabilities](#disclosing-a-vulnerability).  If your vulnerability report is declined, then we will provide you with a reasoning as to why we came to that conclusion.
+
+## Disclosing a Vulnerability
+
+Once an issue is reported, 10up uses the following disclosure process:
+
+- When a report is received, we confirm the issue and determine its severity.
+- If we know of specific third-party services or software that require mitigation before publication, those projects will be notified.
+- An advisory is prepared (but not published) which details the problem and steps for mitigation.
+- Wherever possible, fixes are prepared for the last minor release of the two latest major releases, as well as the master branch.  We will attempt to commit these fixes as soon as possible, and as close together as possible.
+- Patch releases are published for all fixed released versions and the advisory is published.
+- Release notes and our CHANGELOG.md will include a `Security` section with a link to the advisory.
+
+We credit reporters for identifying vulnerabilities, although we will keep your name confidential if you request it.
+
+## Known Vulnerabilities
+
+Past security advisories, if any, are listed below.
+
+| Advisory Number | Type               | Versions affected | Reported by           | Additional Information      |
+|-----------------|--------------------|:-----------------:|-----------------------|-----------------------------|
+| -               | -                  | -                 | -                     | -                           |
+| -               | -                  | -                 | -                     | -                           |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,14 +12,14 @@ The following versions of this project are currently being supported with securi
 
 ## Reporting a Vulnerability
 
-To report a security issue please email details to opensource@10up.com with a descriptive subject line.  This account is monitored by a small team within 10up.  In addition, please include the following information along with your report:
+To report a security issue please email details to opensourcesecurity@10up.com with a descriptive subject line.  This account is monitored by a small team within 10up.  In addition, please include the following information along with your report:
 
 - Your name and affiliation (if any).
 - A description of the technical details of the vulnerability.  It is very important to let us know how we can reproduce your findings.
 - An explanation who can exploit this vulnerability, and what they gain when doing so -- write an attack scenario.  This will help us evaluate your report quickly, especially if the issue is complex.
 - Whether this vulnerability is public or known to third parties.  If it is, please provide details.
 
-If you believe that an existing (public) issue is security-related, please send an email to opensource@10up.com.  The email should include the issue ID and a short description of why it should be handled according to this security policy.
+If you believe that an existing (public) issue is security-related, please send an email to opensourcesecurity@10up.com.  The email should include the issue ID and a short description of why it should be handled according to this security policy.
 
 ## Responding to Vulnerability Reports
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The following SECURITY.md file added to the https://github.com/10up/.github repo should be immediately available across 10up repos on GitHub.  Individual repos can customize this and have their own version locally in their repo, but otherwise will inherit this standard version.

The `Supported Versions` section only makes sense for individual repos that aren’t using the organization-wide version that will be available at https://github.com/10up/.github/SECURITY.md.  The `Known Vulnerabilities` section also only makes sense in individual repos and could be located outside the SECURITY.md file (e.g., https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/index.md).

### Alternate Designs

If relying on email to handle vulnerability reports and triaging is not sufficient, then we can look into utilizing [HackerOne Community Edition](https://www.hackerone.com/product/community) which is free for eligible open source projects.

### Benefits

Ensures a standard security policy is used across 10up repos.

### Possible Drawbacks

none identified

### Verification Process

Manually verified via GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

> ### Added
> - Security Policy (see: SECURITY.md file)