### PR TITLE
Add Site Health Info details to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -29,9 +29,7 @@ assignees: ''
  - Device: <!-- [e.g. MacBook] -->
  - OS: <!-- [e.g. MacOS 10.14.3] -->
  - Browser and version: <!-- [e.g. Firefox 65.0.1, Chrome 73.0.3683.75, Safari 12.0.3] -->
- - Plugins and version: <!-- [e.g. 1.1.0] -->
- - Theme and version: <!-- [e.g. Twenty Nineteen 1.3] -->
- - Other installed plugin(s) and version(s):
+ - Site Health Info: <!-- Go to Tools > Site Health > Info tab, click "Copy site info to clipboard", and paste those details here -->
 
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -29,7 +29,14 @@ assignees: ''
  - Device: <!-- [e.g. MacBook] -->
  - OS: <!-- [e.g. MacOS 10.14.3] -->
  - Browser and version: <!-- [e.g. Firefox 65.0.1, Chrome 73.0.3683.75, Safari 12.0.3] -->
- - Site Health Info: <!-- Go to Tools > Site Health > Info tab, click "Copy site info to clipboard", and paste those details here -->
+ - WordPress version: <!-- [e.g., 5.3.2] -->
+ <!-- If your WordPress version is below 5.2, then please fill out the Plugins and Themes items below. -->
+ - Plugins and version: <!-- [e.g. PluginA 1.0.0, PluginB 2.1.0, PluginC 3.2.1] -->
+ - Theme and version: <!-- [e.g. Twenty Nineteen 1.3] -->
+ <!-- If your WordPress version is 5.2 or higher, then please fill out the Site Health Info details below. -->
+ - <details><summary>Site Health Info:</summary>
+   <!-- Go to Tools > Site Health > Info tab, click "Copy site info to clipboard", and paste those details here. -->
+   </details>
 
 **Additional context**
 <!-- Add any other context about the problem here. -->


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR replaces the lines that request plugin and theme details and instead asks for an export from the Site Health Info page.  We'll get much more complete information from Site Health and as long as folks are running [WP 5.2+](https://make.wordpress.org/core/2019/04/25/site-health-check-in-5-2/) or have the Site Health plugin installed this should be standard (noting that as of today that's [55.7% of installs](https://wordpress.org/about/stats/)).

### Alternate Designs

Keep as-is until WP 5.2+ is a higher percentage of total installs?  Maybe allow for both a Site Health line and additional lines in case Site Health isn't available to self-report plugins/themes?

### Benefits

If we can get Site Health Info details that will provide us with much more info than we normally get and will provide us with valuable information if we're triaging multiple similar issues to try and find potential root causes.

### Possible Drawbacks

A lot more data will get dumped into the description of bug reports.

### Verification Process

Manually verified via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is opex._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

```
### Changed
- Bug report to request Site Health Info instead of manual plugin/theme reporting
```