### PR TITLE
Update 1-bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -29,14 +29,13 @@ assignees: ''
  - Device: <!-- [e.g. MacBook] -->
  - OS: <!-- [e.g. MacOS 10.14.3] -->
  - Browser and version: <!-- [e.g. Firefox 65.0.1, Chrome 73.0.3683.75, Safari 12.0.3] -->
- - WordPress version: <!-- [e.g., 5.3.2] -->
- <!-- If your WordPress version is below 5.2, then please fill out the Plugins and Themes items below. -->
- - Plugins and version: <!-- [e.g. PluginA 1.0.0, PluginB 2.1.0, PluginC 3.2.1] -->
- - Theme and version: <!-- [e.g. Twenty Nineteen 1.3] -->
- <!-- If your WordPress version is 5.2 or higher, then please fill out the Site Health Info details below. -->
- - <details><summary>Site Health Info:</summary>
-   <!-- Go to Tools > Site Health > Info tab, click "Copy site info to clipboard", and paste those details here. -->
-   </details>
+
+**WordPress information**
+<!-- If your WordPress version is below 5.2, then please provide your WordPress, Plugins, Themes versions here. -->
+<!-- If your WordPress version is 5.2 or higher, then please fill out the Site Health Info details below. -->
+<details><summary>Site Health info:</summary>
+<!-- Go to Tools > Site Health > Info tab, click "Copy site info to clipboard", and paste those details here. -->
+</details>
 
 **Additional context**
 <!-- Add any other context about the problem here. -->


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Apparently you cannot include the `details` expand/collapse functionality within a bullet, so this PR moves the Site Health Info details into a new WordPress info section.

### Alternate Designs

n/a

### Benefits

Allows for Site Health Info to be added to a bug report, but not make that content always scrollable as it can be collapsed by default.

### Possible Drawbacks

none identified

### Verification Process

Will see once this is merged.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

n/a