### PR TITLE
Fixes global CONTRIBUTING link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ Describe the actions you performed (e.g., commands you ran, text you typed, butt
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
+- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
### Description of the Change

This fixes the global CONTRIBUTING link which was leading to `https://github.com/CONTRIBUTING.md` which then was leading to `https://github.com/about/careers`. 

I've seen this surfacing in other repositories that don't have specific CONTRIBUTING files. I haven't manually fixed this PR so the issue is visible here too.