### PR TITLE
Stale repository report

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -8,43 +8,8 @@ name: GPL-Compatible License Policy
 # ([String]). Only allow these licenses (optional)
 # Possible values: Any `spdx_id` value(s) from https://docs.github.com/en/rest/licenses 
 # The following list is an attempt to match exactly what's listed on https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses as GPL Compatible (currently ignoring the FSF Free/Libre and OSI Approved column data from the SPDX License List at https://spdx.org/licenses/):
-allow-licenses:
-- 0BSD
-- AGPL-3.0
-- AGPL-3.0-only
-- Apache-2.0
-- Apache-2.0 AND Apache-2.0 WITH LLVM-exception
-- Apache-2.0 WITH LLVM-exception
-- Artistic-2.0
-- BSD-2-Clause
-- BSD-3-Clause
-- BSL-1.0
-- CC-BY-4.0
-- ECL-2.0
-- EFL-2.0
-- EUDatagrid
-- GPL-2.0
-- GPL-2.0-only
-- GPL-2.0-or-later
-- GPL-3.0
-- GPL-3.0-only
-- GPL-3.0-or-later
-- HPND
-- Intel
-- ISC
-- LGPL-3.0
-- LGPL-3.0-only
-- LGPL-2.1
-- LGPL-2.1-only
-- MIT
-- MPL-2.0
-- NCSA
-- Sleepycat
-- Unlicense
-- UPL-1.0
-- W3C
-- Zlib
-- ZPL-2.0
+allow-licenses: 0BSD, AGPL-3.0, AGPL-3.0-only, Apache-2.0, Apache-2.0 AND Apache-2.0 WITH LLVM-exception, Apache-2.0 WITH LLVM-exception, Artistic-2.0, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC-BY-4.0, ECL-2.0, EFL-2.0, EUDatagrid, GPL-2.0, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0, GPL-3.0-only, GPL-3.0-or-later, HPND, Intel, ISC, LGPL-3.0, LGPL-3.0-only, LGPL-2.1, LGPL-2.1-only, MIT, MPL-2.0, NCSA, Sleepycat, Unlicense, UPL-1.0, W3C, Zlib, ZPL-2.0
+
 # The following licenses fit the above criteria except they are not marked as FSF Free/Libre on the SPDX License List (https://spdx.org/licenses/):  Unicode-DFS-2016
 # The following licenses fit the above criteria except they are not marked as OSI Approved on the SPDX License List (https://spdx.org/licenses/): ClArtistic, CECILL-2.0, BSD-3-Clause-Clear, FTL, iMatix, Imlib2, IJG, OLDAP-2.7, Ruby, SGI-B-2.0, SMLNJ, Vim, WTFPL, X11, XFree86-1.1
 

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,15 +1,11 @@
 name: GPL-Compatible License Policy
 
-# Possible values: "critical", "high", "moderate", "low" 
-# fail-on-severity: critical
-
 # You can only include one of these two options: `allow-licenses` and `deny-licences`
 
 # ([String]). Only allow these licenses (optional)
 # Possible values: Any `spdx_id` value(s) from https://docs.github.com/en/rest/licenses 
 # The following list is an attempt to match exactly what's listed on https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses as GPL Compatible (currently ignoring the FSF Free/Libre and OSI Approved column data from the SPDX License List at https://spdx.org/licenses/):
 allow-licenses: 0BSD, AGPL-3.0, AGPL-3.0-only, Apache-2.0, Apache-2.0 AND Apache-2.0 WITH LLVM-exception, Apache-2.0 WITH LLVM-exception, Artistic-2.0, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC-BY-4.0, ECL-2.0, EFL-2.0, EUDatagrid, GPL-2.0, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0, GPL-3.0-only, GPL-3.0-or-later, HPND, Intel, ISC, LGPL-3.0, LGPL-3.0-only, LGPL-2.1, LGPL-2.1-only, MIT, MPL-2.0, NCSA, Sleepycat, Unlicense, UPL-1.0, W3C, Zlib, ZPL-2.0
-
 # The following licenses fit the above criteria except they are not marked as FSF Free/Libre on the SPDX License List (https://spdx.org/licenses/):  Unicode-DFS-2016
 # The following licenses fit the above criteria except they are not marked as OSI Approved on the SPDX License List (https://spdx.org/licenses/): ClArtistic, CECILL-2.0, BSD-3-Clause-Clear, FTL, iMatix, Imlib2, IJG, OLDAP-2.7, Ruby, SGI-B-2.0, SMLNJ, Vim, WTFPL, X11, XFree86-1.1
 

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,55 @@
+name: GPL-Compatible License Policy
+
+# Possible values: "critical", "high", "moderate", "low" 
+# fail-on-severity: critical
+
+# You can only include one of these two options: `allow-licenses` and `deny-licences`
+
+# ([String]). Only allow these licenses (optional)
+# Possible values: Any `spdx_id` value(s) from https://docs.github.com/en/rest/licenses 
+# The following list is an attempt to match exactly what's listed on https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses as GPL Compatible (currently ignoring the FSF Free/Libre and OSI Approved column data from the SPDX License List at https://spdx.org/licenses/):
+allow-licenses:
+- 0BSD
+- AGPL-3.0
+- AGPL-3.0-only
+- Apache-2.0
+- Apache-2.0 AND Apache-2.0 WITH LLVM-exception
+- Apache-2.0 WITH LLVM-exception
+- Artistic-2.0
+- BSD-2-Clause
+- BSD-3-Clause
+- BSL-1.0
+- CC-BY-4.0
+- ECL-2.0
+- EFL-2.0
+- EUDatagrid
+- GPL-2.0
+- GPL-2.0-only
+- GPL-2.0-or-later
+- GPL-3.0
+- GPL-3.0-only
+- GPL-3.0-or-later
+- HPND
+- Intel
+- ISC
+- LGPL-3.0
+- LGPL-3.0-only
+- LGPL-2.1
+- LGPL-2.1-only
+- MIT
+- MPL-2.0
+- NCSA
+- Sleepycat
+- Unlicense
+- UPL-1.0
+- W3C
+- Zlib
+- ZPL-2.0
+# The following licenses fit the above criteria except they are not marked as FSF Free/Libre on the SPDX License List (https://spdx.org/licenses/):  Unicode-DFS-2016
+# The following licenses fit the above criteria except they are not marked as OSI Approved on the SPDX License List (https://spdx.org/licenses/): ClArtistic, CECILL-2.0, BSD-3-Clause-Clear, FTL, iMatix, Imlib2, IJG, OLDAP-2.7, Ruby, SGI-B-2.0, SMLNJ, Vim, WTFPL, X11, XFree86-1.1
+
+# ([String]). Block the pull request on these licenses (optional)
+# Possible values: Any  `spdx_id` value(s) from https://docs.github.com/en/rest/licenses 
+# The following list is an attempt to match exactly what's listed on https://www.gnu.org/licenses/license-list.html#GPLIncompatibleLicenses as GPL Incompatible:
+# deny-licenses: AGPL-1.0, AGPL-1.0-only, AFL-1.1, AFL-1.2, AFL-2.0, AFL-2.1, AFL-3.0, Apache-1.1, Apache-1.0, APSL-2.0, BitTorrent-1.0, BSD-4-Clause, CECILL-B, CECILL-C, CDDL-1.0, CPAL-1.0, CPL-1.0, Condor-1.1, EPL-1.0, EPL-2.0, EUPL-1.1, EUPL-1.2, FDK-AAC, gnuplot, IPL-1.0, LPPL-1.3a, LPPL-1.2, LPL-1.02, MS-PL, MS-RL, MPL-1.1, NOSL, NPL-1.0, NPL-1.1, Nokia, OLDAP-2.3, OSL-1.0, OSL-1.1, OSL-2.0, OSL-2.1, OSL-3.0, OpenSSL, PHP-3.01, Python-2.0, QPL-1.0, RPSL-1.0, SISSL, SPL-1.0, xinetd, YPL-1.1, Zend-2.0, Zimbra-1.3, ZPL-1.1
+# The following list is an attempt, additionally, to match exactly what's listedn on https://www.gnu.org/licenses/license-list.html#NonFreeSoftwareLicenses as Nonfree: Aladdin, APSL-1.0, APSL-1.1, APSL-1.2, Artistic-1.0, CPOL-1.02, RHeCos-1.1, JSON, NASA-1.3, OPL-1.0, RPL-1.1, Watcom-1.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Reqest, surfacing known GPL-incompatible versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known GPL-incompatible packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v2
+        with:
+
+          # You can only can only include one of these two options: `allow-licenses` and `deny-licences`
+          # ([String]). Only allow these licenses (optional)
+          # Possible values: Any `spdx_id` value(s) from https://docs.github.com/en/rest/licenses 
+          # The following list is an attempt to match exactly what's listed on https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses as GPL Compatible (currently ignoring the FSF Free/Libre and OSI Approved column data from the SPDX License List at https://spdx.org/licenses/):
+          allow-licenses: GPL-2.0, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0, GPL-3.0-only, GPL-3.0-or-later, LGPL-3.0, LGPL-3.0-only, LGPL-2.1, LGPL-2.1-only, AGPL-3.0, AGPL-3.0-only, Apache-2.0, Artistic-2.0, Sleepycat, BSL-1.0, BSD-3-Clause, ECL-2.0, EFL-2.0, EUDatagrid, MIT, BSD-2-Clause, HPND, Intel, ISC, MPL-2.0, NCSA, UPL-1.0, Unlicense, W3C, Zlib, ZPL-2.0
+          # The following licenses fit the above criteria except they are not marked as FSF Free/Libre on the SPDX License List (https://spdx.org/licenses/):  Unicode-DFS-2016
+          # The following licenses fit the above criteria except they are not marked as OSI Approved on the SPDX License List (https://spdx.org/licenses/): ClArtistic, CECILL-2.0, BSD-3-Clause-Clear, FTL, iMatix, Imlib2, IJG, OLDAP-2.7, Ruby, SGI-B-2.0, SMLNJ, Vim, WTFPL, X11, XFree86-1.1
+          # ([String]). Block the pull request on these licenses (optional)
+          # Possible values: Any  `spdx_id` value(s) from https://docs.github.com/en/rest/licenses 
+          # The following list is an attempt to match exactly what's listed on https://www.gnu.org/licenses/license-list.html#GPLIncompatibleLicenses as GPL Incompatible:
+          # deny-licenses: AGPL-1.0, AGPL-1.0-only, AFL-1.1, AFL-1.2, AFL-2.0, AFL-2.1, AFL-3.0, Apache-1.1, Apache-1.0, APSL-2.0, BitTorrent-1.0, BSD-4-Clause, CECILL-B, CECILL-C, CDDL-1.0, CPAL-1.0, CPL-1.0, Condor-1.1, EPL-1.0, EPL-2.0, EUPL-1.1, EUPL-1.2, FDK-AAC, gnuplot, IPL-1.0, LPPL-1.3a, LPPL-1.2, LPL-1.02, MS-PL, MS-RL, MPL-1.1, NOSL, NPL-1.0, NPL-1.1, Nokia, OLDAP-2.3, OSL-1.0, OSL-1.1, OSL-2.0, OSL-2.1, OSL-3.0, OpenSSL, PHP-3.01, Python-2.0, QPL-1.0, RPSL-1.0, SISSL, SPL-1.0, xinetd, YPL-1.1, Zend-2.0, Zimbra-1.3, ZPL-1.1
+          # The following list is an attempt, additionally, to match exactly what's listedn on https://www.gnu.org/licenses/license-list.html#NonFreeSoftwareLicenses as Nonfree: Aladdin, APSL-1.0, APSL-1.1, APSL-1.2, Artistic-1.0, CPOL-1.02, RHeCos-1.1, JSON, NASA-1.3, OPL-1.0, RPL-1.1, Watcom-1.0


### PR DESCRIPTION
# Inactive Repositories

The following repos have not had a push event for more than 365 days:

| Repository URL | Days Inactive | Last Push Date |
| --- | ---: | ---: | 
| https://github.com/github/.github | 5 | 2020-1-30 |