### PR TITLE
fix/workflow-perms

### DIFF
--- a/.github/workflows/stale_repos.yml
+++ b/.github/workflows/stale_repos.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '3 2 1 * *'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   build:
     name: stale repo identifier


### PR DESCRIPTION
Potential fix for [https://github.com/10up/.github/security/code-scanning/1](https://github.com/10up/.github/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's functionality:
- The `contents: read` permission is sufficient for most steps.
- The `issues: write` permission is required for the step that creates or updates issues.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as the workflow does not define multiple jobs with differing permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
