### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ Please include a summary for this PR, noting whether this is something being Add
 
 ### Credits
 <!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
-Props @username, @username2, ...
+Props @username, ...
 
 ### Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


### PR DESCRIPTION
Currently the PR template includes a reference to a real username in the list under the _Credits_ section.

<img width="608" height="174" alt="image" src="https://github.com/user-attachments/assets/aed84343-4c80-4dac-8348-378d047d7a02" />

It seems `@username` is a reserved name which can't be used so this should be fine to keep.

While this doesn't notify the user for private repos (which would be a concern), it would for public contributions if left with the default content, but we generally shouldn't be referencing any real usernames in the template.

