### PR TITLE
Add new licenses to dependency review config

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -16,8 +16,11 @@ allow-licenses:
 - Apache-2.0 AND Apache-2.0 WITH LLVM-exception
 - Apache-2.0 WITH LLVM-exception
 - Artistic-2.0
+- BlueOak-1.0.0
+- BSD
 - BSD-2-Clause
 - BSD-3-Clause
+- BSD-3-Clause-W3C
 - BSL-1.0
 - CC0-1.0
 - CC-BY-4.0
@@ -38,13 +41,17 @@ allow-licenses:
 - LGPL-2.1
 - LGPL-2.1-only
 - MIT
+- MIT/X11
 - MIT-0
 - MPL-2.0
 - NCSA
+- ODC-By-1.0
 - Sleepycat
 - Unlicense
 - UPL-1.0
+- WTFPL
 - W3C
+- W3C-20150513
 - Zlib
 - ZPL-2.0
 # The following licenses fit the above criteria except they are not marked as FSF Free/Libre on the SPDX License List (https://spdx.org/licenses/):  Unicode-DFS-2016


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In researching GPL-compatible licenses today, don't ask it was a rabbit hole sort of a day, I noticed there were updates to the Gutenberg approved GPL-compatible license list that we might as well inherit into our list here.

This PR adds `BlueOak-1.0.0`, `BSD`, `BSD-3-Clause-W3C`, `MIT/X11`, `ODC-By-1.0`, `W3C-20150513`, and `WTFPL` to be current with updated licenses from Gutenberg last updated in https://github.com/WordPress/gutenberg/commit/f58d95823071ed4bf77dd610b62dd0f893907061#diff-9f449756c2a6bc09b38edf1c3355523a0fb226ab2a2e7d1800a3a52cb34b35f8.

You can continue to read through the blame in the Gutenberg repo to see where licenses besides Blue Oak are added in, after reading through git history I'm content updating to add these licenses to our listing here.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - `BlueOak-1.0.0`, `BSD`, `BSD-3-Clause-W3C`, `MIT/X11`, `ODC-By-1.0`, `W3C-20150513`, and `WTFPL` to the GPL-compatible license listing.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
